### PR TITLE
feat: progressive loading support

### DIFF
--- a/components/cow/cow.css
+++ b/components/cow/cow.css
@@ -1,0 +1,3 @@
+progressive-cow {
+  color: dimgray;
+}

--- a/components/cow/cow.css
+++ b/components/cow/cow.css
@@ -1,3 +1,3 @@
 progressive-cow {
-  color: dimgray;
+  color: green;
 }

--- a/components/cow/cow.js
+++ b/components/cow/cow.js
@@ -2,7 +2,7 @@ import StacheElement from "can-stache-element"
 import { ssrDefineElement } from "../../jsdom-ssr/ssr-helpers"
 import "./cow.css"
 
-class MyCow extends StacheElement {
+class Cow extends StacheElement {
   static view = `
     <h3>Cow</h3>
     <p>Top 5 animal in the world is Cow</p>
@@ -26,4 +26,4 @@ class MyCow extends StacheElement {
   }
 }
 
-ssrDefineElement("progressive-cow", MyCow)
+ssrDefineElement("progressive-cow", Cow)

--- a/components/cow/cow.js
+++ b/components/cow/cow.js
@@ -6,7 +6,24 @@ class MyCow extends StacheElement {
   static view = `
     <h3>Cow</h3>
     <p>Top 5 animal in the world is Cow</p>
+    <p>First: {{ first }}</p>
+    <p>Second: {{ second }}</p>
   `
+
+  static props = {
+    first: "",
+    second: "",
+  }
+
+  connected() {
+    setTimeout(() => {
+      this.first = "300 milliseconds have passed"
+    }, 300)
+
+    setTimeout(() => {
+      this.second = "0.01 minutes have passed"
+    }, 600)
+  }
 }
 
 ssrDefineElement("progressive-cow", MyCow)

--- a/components/cow/cow.js
+++ b/components/cow/cow.js
@@ -1,0 +1,14 @@
+import StacheElement from "can-stache-element"
+import "can-stache-route-helpers"
+import { ssrDefineElement } from "../../jsdom-ssr/ssr-helpers"
+import "./cow.css"
+
+class MyCow extends StacheElement {
+  static view = `
+        <h3>Cow</h3>
+        <p>Top 5 animal in the world is Cow</p>
+    `
+}
+
+// customElements.define("progressive-cow", MyCow)
+ssrDefineElement("progressive-cow", MyCow)

--- a/components/cow/cow.js
+++ b/components/cow/cow.js
@@ -1,14 +1,12 @@
 import StacheElement from "can-stache-element"
-import "can-stache-route-helpers"
 import { ssrDefineElement } from "../../jsdom-ssr/ssr-helpers"
 import "./cow.css"
 
 class MyCow extends StacheElement {
   static view = `
-        <h3>Cow</h3>
-        <p>Top 5 animal in the world is Cow</p>
-    `
+    <h3>Cow</h3>
+    <p>Top 5 animal in the world is Cow</p>
+  `
 }
 
-// customElements.define("progressive-cow", MyCow)
 ssrDefineElement("progressive-cow", MyCow)

--- a/components/moo/moo.css
+++ b/components/moo/moo.css
@@ -1,4 +1,3 @@
-my-root {
-  background: darkgray;
-  text: white;
+progressive-moo {
+  color: orangered;
 }

--- a/components/moo/moo.css
+++ b/components/moo/moo.css
@@ -1,0 +1,4 @@
+my-root {
+  background: darkgray;
+  text: white;
+}

--- a/components/moo/moo.js
+++ b/components/moo/moo.js
@@ -1,15 +1,51 @@
 import StacheElement from "can-stache-element"
-import "can-stache-route-helpers"
 import { ssrDefineElement } from "../../jsdom-ssr/ssr-helpers"
 import "./moo.css"
 
 class MyMoo extends StacheElement {
   static view = `
-        <h3>Moo</h3>
-        <p>Cows go Moooo~~</p>
-    `
-}
-console.log("progressive-moo loaded")
+    <h3>Moo</h3>
+    <p>Cows go Moooo~~</p>
+    <p>First: {{ first }}</p>
+    <p>Second: {{ second }}</p>
+  `
 
-// customElements.define("progressive-moo", MyMoo)// <-- works
-ssrDefineElement("progressive-moo", MyMoo) // <-- doesn't work ):
+  static props = {
+    first: "",
+    second: "",
+  }
+
+  connected() {
+    if (this.INERT_PRERENDERED) {
+      return
+    }
+
+    setTimeout(() => {
+      xhrGet("https://dummyjson.com/products?limit=10&skip=10&select=title,price").then((jsonData) => {
+        this.first = jsonData.products[0].title
+      })
+    }, 1)
+
+    xhrGet("https://dummyjson.com/quotes").then((jsonData) => {
+      this.second = jsonData.quotes[0].quote
+    })
+  }
+}
+
+ssrDefineElement("progressive-moo", MyMoo)
+
+// Copied from main.js
+function xhrGet(url) {
+  return new Promise((res) => {
+    const req = new XMLHttpRequest()
+    req.onload = () => {
+      if (req.readyState === req.DONE) {
+        if (req.status === 200) {
+          res(JSON.parse(req.responseText))
+        }
+      }
+    }
+    req.open("GET", url)
+    req.send()
+  })
+}

--- a/components/moo/moo.js
+++ b/components/moo/moo.js
@@ -2,7 +2,7 @@ import StacheElement from "can-stache-element"
 import { ssrDefineElement } from "../../jsdom-ssr/ssr-helpers"
 import "./moo.css"
 
-class MyMoo extends StacheElement {
+class Moo extends StacheElement {
   static view = `
     <h3>Moo</h3>
     <p>Cows go Moooo~~</p>
@@ -32,7 +32,7 @@ class MyMoo extends StacheElement {
   }
 }
 
-ssrDefineElement("progressive-moo", MyMoo)
+ssrDefineElement("progressive-moo", Moo)
 
 // Copied from main.js
 function xhrGet(url) {

--- a/components/moo/moo.js
+++ b/components/moo/moo.js
@@ -1,0 +1,15 @@
+import StacheElement from "can-stache-element"
+import "can-stache-route-helpers"
+import { ssrDefineElement } from "../../jsdom-ssr/ssr-helpers"
+import "./moo.css"
+
+class MyMoo extends StacheElement {
+  static view = `
+        <h3>Moo</h3>
+        <p>Cows go Moooo~~</p>
+    `
+}
+console.log("progressive-moo loaded")
+
+// customElements.define("progressive-moo", MyMoo)// <-- works
+ssrDefineElement("progressive-moo", MyMoo) // <-- doesn't work ):

--- a/components/root/root.css
+++ b/components/root/root.css
@@ -1,4 +1,3 @@
-my-root {
-  background: purple;
-  text: teal;
+progressive-root {
+  color: deeppink;
 }

--- a/components/root/root.css
+++ b/components/root/root.css
@@ -1,0 +1,4 @@
+my-root {
+  background: purple;
+  text: teal;
+}

--- a/components/root/root.js
+++ b/components/root/root.js
@@ -1,28 +1,25 @@
 import StacheElement from "can-stache-element"
-import { ssrDefineElement } from "../../jsdom-ssr/ssr-helpers"
+import { ssrDefineElement, stealImport } from "../../jsdom-ssr/ssr-helpers"
 import route from "can-route"
 import "can-stache-route-helpers"
-// import "../moo/moo";
-import "../cow/cow"
+// import "../moo/moo"
+// import "../cow/cow"
 import "./root.css"
-
-// route.register("progressive-loading/moo", { loadId: "moo", page: "moo" });
-// route.register("progressive-loading/cow", { loadId: "cow", page: "cow" });
 
 export class MyRoot extends StacheElement {
   static view = `
-        <a href="{{ routeUrl(loadId='cow') }}">Cow</a> <a href="{{ routeUrl(loadId='moo') }}">Moo</a> <a href="{{ routeUrl(loadId='root') }}">Root</a>
+    <a href="{{ routeUrl(loadId='cow') }}">Cow</a> <a href="{{ routeUrl(loadId='moo') }}">Moo</a> <a href="{{ routeUrl(loadId='root') }}">Root</a>
 
-        {{# if(this.comp.isPending) }}
-            Loading...
-        {{/ if }}
-        {{# if(this.comp.isRejected) }}
-            Rejected {{ comp.reason }}
-        {{/ if }}
-        {{# if(this.comp.isResolved) }}
-            {{ comp.value }}
-        {{/ if }}
-    `
+    {{# if(this.comp.isPending) }}
+        <h2>Loading...</h2>
+    {{/ if }}
+    {{# if(this.comp.isRejected) }}
+      <h2>Rejected {{ comp.reason }}</h2>
+    {{/ if }}
+    {{# if(this.comp.isResolved) }}
+        {{ comp.value }}
+    {{/ if }}
+  `
 
   static props = {
     routeData: {
@@ -34,7 +31,7 @@ export class MyRoot extends StacheElement {
 
   get comp() {
     const loadId = this.routeData.loadId
-    console.log("comp", loadId)
+    console.log("route.data.loadId", loadId)
 
     if (!loadId || loadId === "root") {
       const root = document.createElement("h2")
@@ -43,41 +40,26 @@ export class MyRoot extends StacheElement {
     }
 
     if (loadId === "moo") {
-      // const root = document.createElement("h2");
-      // root.innerHTML = "Welcome Moo";
-      // return Promise.resolve(root);
-      // return Promise.resolve(document.createElement('progressive-moo'));
-      return steal.import(`can-stache-element-ssr/components/moo/moo`).then(() => {
-        const div = document.createElement("div")
-        const temp = document.createElement("progressive-moo")
-        div.appendChild(temp)
-        const span = document.createElement("span")
-        span.innerText = "moocow"
-        div.appendChild(span)
-        return div
+      return stealImport(`can-stache-element-ssr/components/moo/moo`, function () {
+        return document.createElement("progressive-moo")
       })
+
+      // TODO: Check this
+      // return steal.import(`can-stache-element-ssr/components/moo/moo`).then(() => {
+      //   return document.createElement("progressive-moo")
+      // })
     }
 
     if (loadId === "cow") {
-      // const root = document.createElement("h2");
-      // root.innerHTML = "Welcome Cow";
-      // return Promise.resolve(root);
-      return Promise.resolve(document.createElement("progressive-cow"))
+      return steal.import(`can-stache-element-ssr/components/cow/cow`).then(() => {
+        return document.createElement("progressive-cow")
+      })
     }
 
     const unknown = document.createElement("h2")
     unknown.innerHTML = "Progressive Loading 404"
     return Promise.resolve(unknown)
-
-    // return steal.import(`myhub/${hash}/${hash}`).then(function(moduleOrPlugin){
-    //     var plugin = typeof moduleOrPlugin === "function" ?
-    //         moduleOrPlugin : moduleOrPlugin["default"];
-
-    //     const ele = document.createElement('div');
-    //     return plugin();
-    // });
   }
 }
 
-// customElements.define("progressive-loading", MyRoot)
 ssrDefineElement("progressive-loading", MyRoot)

--- a/components/root/root.js
+++ b/components/root/root.js
@@ -6,7 +6,7 @@ import "can-stache-route-helpers"
 // import "../cow/cow"
 import "./root.css"
 
-export class MyRoot extends StacheElement {
+export class Root extends StacheElement {
   static view = `
     <a href="{{ routeUrl(loadId='cow') }}">Cow</a> <a href="{{ routeUrl(loadId='moo') }}">Moo</a> <a href="{{ routeUrl(loadId='root') }}">Root</a>
 
@@ -57,4 +57,4 @@ export class MyRoot extends StacheElement {
   }
 }
 
-ssrDefineElement("progressive-loading", MyRoot)
+ssrDefineElement("progressive-root", Root)

--- a/components/root/root.js
+++ b/components/root/root.js
@@ -1,5 +1,5 @@
 import StacheElement from "can-stache-element"
-import { ssrDefineElement, stealImport } from "../../jsdom-ssr/ssr-helpers"
+import { ssrDefineElement } from "../../jsdom-ssr/ssr-helpers"
 import route from "can-route"
 import "can-stache-route-helpers"
 // import "../moo/moo"
@@ -40,14 +40,9 @@ export class MyRoot extends StacheElement {
     }
 
     if (loadId === "moo") {
-      return stealImport(`can-stache-element-ssr/components/moo/moo`, function () {
+      return steal.import(`can-stache-element-ssr/components/moo/moo`).then(() => {
         return document.createElement("progressive-moo")
       })
-
-      // TODO: Check this
-      // return steal.import(`can-stache-element-ssr/components/moo/moo`).then(() => {
-      //   return document.createElement("progressive-moo")
-      // })
     }
 
     if (loadId === "cow") {

--- a/components/root/root.js
+++ b/components/root/root.js
@@ -1,0 +1,83 @@
+import StacheElement from "can-stache-element"
+import { ssrDefineElement } from "../../jsdom-ssr/ssr-helpers"
+import route from "can-route"
+import "can-stache-route-helpers"
+// import "../moo/moo";
+import "../cow/cow"
+import "./root.css"
+
+// route.register("progressive-loading/moo", { loadId: "moo", page: "moo" });
+// route.register("progressive-loading/cow", { loadId: "cow", page: "cow" });
+
+export class MyRoot extends StacheElement {
+  static view = `
+        <a href="{{ routeUrl(loadId='cow') }}">Cow</a> <a href="{{ routeUrl(loadId='moo') }}">Moo</a> <a href="{{ routeUrl(loadId='root') }}">Root</a>
+
+        {{# if(this.comp.isPending) }}
+            Loading...
+        {{/ if }}
+        {{# if(this.comp.isRejected) }}
+            Rejected {{ comp.reason }}
+        {{/ if }}
+        {{# if(this.comp.isResolved) }}
+            {{ comp.value }}
+        {{/ if }}
+    `
+
+  static props = {
+    routeData: {
+      get default() {
+        return route.data
+      },
+    },
+  }
+
+  get comp() {
+    const loadId = this.routeData.loadId
+    console.log("comp", loadId)
+
+    if (!loadId || loadId === "root") {
+      const root = document.createElement("h2")
+      root.innerHTML = "Welcome Root"
+      return Promise.resolve(root)
+    }
+
+    if (loadId === "moo") {
+      // const root = document.createElement("h2");
+      // root.innerHTML = "Welcome Moo";
+      // return Promise.resolve(root);
+      // return Promise.resolve(document.createElement('progressive-moo'));
+      return steal.import(`can-stache-element-ssr/components/moo/moo`).then(() => {
+        const div = document.createElement("div")
+        const temp = document.createElement("progressive-moo")
+        div.appendChild(temp)
+        const span = document.createElement("span")
+        span.innerText = "moocow"
+        div.appendChild(span)
+        return div
+      })
+    }
+
+    if (loadId === "cow") {
+      // const root = document.createElement("h2");
+      // root.innerHTML = "Welcome Cow";
+      // return Promise.resolve(root);
+      return Promise.resolve(document.createElement("progressive-cow"))
+    }
+
+    const unknown = document.createElement("h2")
+    unknown.innerHTML = "Progressive Loading 404"
+    return Promise.resolve(unknown)
+
+    // return steal.import(`myhub/${hash}/${hash}`).then(function(moduleOrPlugin){
+    //     var plugin = typeof moduleOrPlugin === "function" ?
+    //         moduleOrPlugin : moduleOrPlugin["default"];
+
+    //     const ele = document.createElement('div');
+    //     return plugin();
+    // });
+  }
+}
+
+// customElements.define("progressive-loading", MyRoot)
+ssrDefineElement("progressive-loading", MyRoot)

--- a/jsdom-ssr/scrape.js
+++ b/jsdom-ssr/scrape.js
@@ -1,6 +1,7 @@
 const steal = require("steal")
 const setupGlobals = require("./setup-globals")
 const { outputFile, existsSync, readFileSync } = require("fs-extra")
+const getFilepath = require("../util/get-filepath")
 const argv = require("optimist").argv
 
 // Get url from argv
@@ -98,19 +99,5 @@ async function scrapeDocument() {
   html = html.replace(/(<canjs-app[^>]*)>/, "$1 data-canjs-static-render>")
   // html = html.replace("</body>", injectHydrateInZoneWithCache + "</body>")
 
-  await outputFile(`dist/ssr/${getFilename(url)}.html`, html)
-}
-
-/**
- * Create filename based on url
- *
- * TODO: consider query params (or confirm that they aren't a part of requirements)
- */
-function getFilename(url) {
-  const path = url
-    .replace(/https?:\/\//, "")
-    .replace(/[^a-zA-Z0-9 /]/g, "_")
-    .replace(/^[^/]*?(\/|$)/, "")
-
-  return `${path}/index`.replace(/^\//, "")
+  await outputFile(`dist/ssr/${getFilepath(url, "index.html")}`, html)
 }

--- a/jsdom-ssr/scrape.js
+++ b/jsdom-ssr/scrape.js
@@ -89,7 +89,13 @@ async function scrapeDocument() {
   let html = window.document.documentElement.outerHTML
 
   // Set Inert Prerendered flag
-  html = html.replace(/(<head[^>]*>)/, "$1<script>globalThis.canStacheElementInertPrerendered = true;</script>")
+  html = html.replace(
+    /(<head[^>]*>)/,
+    `$1<script>
+    globalThis.canStacheElementInertPrerendered = true;
+    globalThis.canMooStache = true;
+  </script>`,
+  )
 
   // Re-inject steal before closing of body tag
   // It's required that steal is injected at the end of body to avoid runtime errors involving `CustomElement`

--- a/jsdom-ssr/ssr-helpers.js
+++ b/jsdom-ssr/ssr-helpers.js
@@ -1,10 +1,21 @@
-// import globals from "can-globals"
 import Zone from "can-zone"
 import xhrZone from "can-zone/xhr"
 
 const sharedZone = new Zone({ plugins: [xhrZone] })
 export const ssrDefineElement = (...args) => {
   sharedZone.run(() => customElements.define(...args))
+}
+
+// TODO: check if in cache already
+export const stealImport = (stealPath, callback) => {
+  return new Promise((resolve) => {
+    sharedZone.run(() => {
+      return steal.import(stealPath).then((data) => {
+        console.log({ data })
+        resolve(callback())
+      })
+    })
+  })
 }
 
 export const ssrEnd = () => {

--- a/jsdom-ssr/ssr-helpers.js
+++ b/jsdom-ssr/ssr-helpers.js
@@ -47,10 +47,10 @@ export const ssrEnd = () => {
         return { staticapp, liveapp }
       })
       .then(function (data) {
+        delete globalThis.canMooStache
         const { staticapp, liveapp } = data.result
         staticapp.remove()
         liveapp.style.display = ""
-        // console.log("it's alive!")
       })
   }
 }

--- a/jsdom-ssr/ssr-helpers.js
+++ b/jsdom-ssr/ssr-helpers.js
@@ -6,12 +6,15 @@ export const ssrDefineElement = (...args) => {
   sharedZone.run(() => customElements.define(...args))
 }
 
-// TODO: check if in cache already
+/**
+ * @deprecated You should be able to just use `steal.import` directly
+ *
+ * Gonna keep this here for now in case it turns out not to be true
+ */
 export const stealImport = (stealPath, callback) => {
   return new Promise((resolve) => {
     sharedZone.run(() => {
       return steal.import(stealPath).then((data) => {
-        console.log({ data })
         resolve(callback())
       })
     })

--- a/main.js
+++ b/main.js
@@ -27,26 +27,29 @@ class MyRoutingApp extends StacheElement {
     routeData: {
       get default() {
         // set default page to the first slug, ignore "dev" or "prod" sentinel
-        const page =
-          window.location.pathname.split("/").filter((slug) => {
-            return slug && slug !== "dev" && slug !== "prod" && slug !== "dist"
-          })[0] || "home"
+
+        // Strip dev, prod, or dist and override route data
+        const routeDataOverrides = window.location.pathname.split("/").filter((slug) => {
+          return slug && slug !== "dev" && slug !== "prod" && slug !== "dist"
+        })
+
+        const page = routeDataOverrides[0] || "home"
+        const loadId = routeDataOverrides[1]
 
         route.register("{page}", { page: "home" })
         route.register("tasks/{taskId}", { page: "tasks" })
-        route.register("progressive-loading/{loadId}", { loadId: "root", page: "progressive-loading" })
-        route.register("progressive-loading/moo", { loadId: "moo", page: "moo" })
-        route.register("progressive-loading/cow", { loadId: "cow", page: "cow" })
+        route.register("progressive-loading/{loadId}", { page: "progressive-loading" })
 
         route.start()
         route.data.page = page
+        route.data.loadId = loadId
         return route.data
       },
     },
   }
 
   get componentToShow() {
-    console.log("componentToShow", this.routeData.page)
+    console.log("route.data.page", this.routeData.page)
 
     // TODO: Progressive loading
     switch (this.routeData.page) {

--- a/main.js
+++ b/main.js
@@ -5,6 +5,7 @@ import "can-stache-route-helpers"
 import view from "./app.stache"
 import { ssrDefineElement, ssrEnd } from "./jsdom-ssr/ssr-helpers.js"
 import "./styles.css"
+import "./components/root/root"
 
 import RoutePushstate from "can-route-pushstate"
 route.urlData = new RoutePushstate()
@@ -12,10 +13,13 @@ route.urlData = new RoutePushstate()
 class MyRoutingApp extends StacheElement {
   static view = `
     {{ this.componentToShow }}
-    <span>Routes: </span>
-    <a href="{{ routeUrl(page='home') }}">Home</a>
-    <a href="{{ routeUrl(page='tasks') }}">Tasks</a>
-    <a href="{{ routeUrl(page='unknown') }}">404</a>
+    <div>
+      <span>Routes: </span>
+      <a href="{{ routeUrl(page='home') }}">Home</a>
+      <a href="{{ routeUrl(page='tasks') }}">Tasks</a>
+      <a href="{{ routeUrl(page='unknown') }}">404</a>
+      <a href="{{ routeUrl(page='progressive-loading') }}">Progressive Loading</a>
+    </div>
     <p>The current page is {{ this.routeData.page }}.</p>
   `
 
@@ -27,8 +31,13 @@ class MyRoutingApp extends StacheElement {
           window.location.pathname.split("/").filter((slug) => {
             return slug && slug !== "dev" && slug !== "prod" && slug !== "dist"
           })[0] || "home"
+
         route.register("{page}", { page: "home" })
         route.register("tasks/{taskId}", { page: "tasks" })
+        route.register("progressive-loading/{loadId}", { loadId: "root", page: "progressive-loading" })
+        route.register("progressive-loading/moo", { loadId: "moo", page: "moo" })
+        route.register("progressive-loading/cow", { loadId: "cow", page: "cow" })
+
         route.start()
         route.data.page = page
         return route.data
@@ -49,6 +58,8 @@ class MyRoutingApp extends StacheElement {
         const tasks = document.createElement("h2")
         tasks.innerHTML = "Tasks"
         return tasks
+      case "progressive-loading":
+        return document.createElement("progressive-loading")
       default:
         const page404 = document.createElement("h2")
         page404.innerHTML = "Page Missing"

--- a/main.js
+++ b/main.js
@@ -62,7 +62,7 @@ class MyRoutingApp extends StacheElement {
         tasks.innerHTML = "Tasks"
         return tasks
       case "progressive-loading":
-        return document.createElement("progressive-loading")
+        return document.createElement("progressive-root")
       default:
         const page404 = document.createElement("h2")
         page404.innerHTML = "Page Missing"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2387,8 +2387,8 @@
       }
     },
     "can-stache-element": {
-      "version": "git+ssh://git@github.com/canjs/can-stache-element.git#61bc9b98d4f06ce1e0d96c7a3f82aa11a44705b4",
-      "from": "git+ssh://git@github.com/canjs/can-stache-element.git#allow-static-inert",
+      "version": "git+ssh://git@github.com/canjs/can-stache-element.git#f08da66e194aa784b210b244bd30729b27267dfd",
+      "from": "git+ssh://git@github.com/canjs/can-stache-element.git#allow-static-inert-extended",
       "requires": {
         "can-bind": "^1.5.0",
         "can-define-lazy-value": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "can": "^6.6.2",
     "can-route": "^5.0.2",
-    "can-stache-element": "git+ssh://git@github.com/canjs/can-stache-element#allow-static-inert",
+    "can-stache-element": "git+ssh://git@github.com/canjs/can-stache-element#allow-static-inert-extended",
     "can-stache-route-helpers": "^2.0.0",
     "can-type": "^1.1.6",
     "can-zone": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
     "plugins": [
       "can",
       "steal-css"
+    ],
+    "bundle": [
+      "can-stache-element-ssr/components/moo/moo",
+      "can-stache-element-ssr/components/cow/cow"
     ]
   },
   "dependencies": {

--- a/server.js
+++ b/server.js
@@ -7,7 +7,9 @@ const app = express()
 
 const ssrDist = "dist/ssr"
 
-const sendFileOr404 = (req, res, dest) => {
+const sendFileOr404 = (req, res, reqPath) => {
+  const dest = path.join(__dirname, reqPath)
+
   if (existsSync(dest)) {
     res.sendFile(dest)
   } else {
@@ -22,9 +24,9 @@ app.get("/*", function (req, res) {
   if (reqPath.indexOf(".") !== -1) {
     // pointing straight to a file? Serve the file
     if (reqPath.startsWith("/prod")) {
-      sendFileOr404(req, res, path.join(__dirname, reqPath.replace("/prod", "")))
+      sendFileOr404(req, res, reqPath.replace("/prod", ""))
     } else {
-      sendFileOr404(req, res, path.join(__dirname, reqPath))
+      sendFileOr404(req, res, reqPath)
     }
   } else if (reqPath.indexOf("/dev") === 0 || argv.dev) {
     // it's not a file, it's a directory's index.html file to load
@@ -38,7 +40,7 @@ app.get("/*", function (req, res) {
     res.sendFile(path.join(__dirname, "/production.html"))
   } else {
     // it's still a directory but it didn't start with /dev, so serve from the static dist folder
-    sendFileOr404(req, res, path.join(__dirname, ssrDist, reqPath, "/index.html"))
+    sendFileOr404(req, res, path.join(ssrDist, reqPath, "/index.html"))
   }
 })
 

--- a/server.js
+++ b/server.js
@@ -14,9 +14,7 @@ const sendFileOr404 = (req, res, reqPath) => {
   // ex "/progressive-loading/dist/bundles/can-stache-element-ssr/main.css"
   // Issue only affects prod
   if (reqPath.includes("dist/bundles")) {
-    console.log(reqPath)
     reqPath = /^.*(dist\/bundles.*)/.exec(reqPath)[1]
-    console.log(reqPath)
   }
 
   const dest = path.join(__dirname, reqPath)

--- a/ssg.json
+++ b/ssg.json
@@ -1,3 +1,10 @@
 {
-  "routes": ["http://127.0.0.1:5501", "http://127.0.0.1:5501/tasks", "http://127.0.0.1:5501/404"]
+  "routes": [
+    "http://127.0.0.1:8080",
+    "http://127.0.0.1:8080/tasks",
+    "http://127.0.0.1:8080/progressive-loading",
+    "http://127.0.0.1:8080/progressive-loading/moo",
+    "http://127.0.0.1:8080/progressive-loading/cow",
+    "http://127.0.0.1:8080/404"
+  ]
 }

--- a/ssg.json
+++ b/ssg.json
@@ -3,6 +3,7 @@
     "http://127.0.0.1:8080",
     "http://127.0.0.1:8080/tasks",
     "http://127.0.0.1:8080/progressive-loading",
+    "http://127.0.0.1:8080/progressive-loading/root",
     "http://127.0.0.1:8080/progressive-loading/moo",
     "http://127.0.0.1:8080/progressive-loading/cow",
     "http://127.0.0.1:8080/404"

--- a/util/get-filepath.js
+++ b/util/get-filepath.js
@@ -1,0 +1,13 @@
+/**
+ * Create a normalized file path based on url
+ *
+ * TODO: consider query params (or confirm that they aren't a part of requirements)
+ */
+module.exports = function (url, filename) {
+  const path = url
+    .replace(/https?:\/\//, "")
+    .replace(/[^a-zA-Z0-9- /]/g, "_")
+    .replace(/^[^/]*?(\/|$)/, "")
+
+  return `${path}/${filename}`.replace(/^\//, "")
+}


### PR DESCRIPTION
### Description

Added support for progressive loading:
1. adding Root (progressive-root), Moo (progressive-moo), Cow (progressive-cow) stache elements
2. adding logic to support nested routes in server for static pages
3. added another globalThis flag to support handling edge cases where static elements are defined in a progressively loaded file (Moo and Cow)
4. Added logic to use xhr (Moo) and setTimeout (Cow)

This PR introduces updates to `package.json` so be sure to `npm i` when merged~